### PR TITLE
[CU-86dtt1gp1] Remove personal names from blog site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,14 +14,14 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 title: Transparency Matters
-email: johnny@lockdownprivacy.com
+email: team@lockdownprivacy.com
 description: >- # this means to ignore newlines until "baseurl:"
   Nuanced takes on transparency, privacy, and incentives.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://blog.lockdownprivacy.com" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: lockdown_hq
 github_username:  confirmedcode
-author: Johnny Lin
+author: Lockdown Privacy
 
 show_excerpts: true
 excerpt_separator: <!--more-->

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -3,30 +3,31 @@ layout: default
 ---
 
 <div class="home">
-  {%- if page.title -%}
+    {%- if page.title -%}
     <h1 class="page-heading">{{ page.title }}</h1>
-  {%- endif -%}
+    {%- endif -%}
 
-  <p style="margin-top: 0px; padding-top: 0px; padding-bottom: 20px;">A blog about transparency, privacy, and incentives. Written by <a href="mailto:johnny@lockdownprivacy.com">Johnny Lin</a>, an ex-iCloud engineer who co-founded the <a href="https://lockdownprivacy.com/" target=_blank>Lockdown Privacy</a> app, and <a href="https://openaudit.com/lockdownprivacy" target=_blank>OpenAudit</a>, the open source auditing platform.</p>
+    <p style="margin-top: 0px; padding-top: 0px; padding-bottom: 20px;">A blog about transparency, privacy, and
+        incentives.</p>
 
-  {{ content }}
+    {{ content }}
 
-  {%- if site.posts.size > 0 -%}
+    {%- if site.posts.size > 0 -%}
     <ul class="post-list">
-      {%- for post in site.posts -%}
-      <li>
-        {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
-        <h3 style="margin-bottom: 0px;">
-          <a class="post-link" href="{{ post.url | relative_url }}">
-            {{ post.title | escape }}
-          </a>
-        </h3>
-        {%- if site.show_excerpts -%}
-          <div style="color:gray;">{{ post.excerpt }}</div>
-        {%- endif -%}
-      </li>
-      {%- endfor -%}
+        {%- for post in site.posts -%}
+        <li>
+            {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+            <h3 style="margin-bottom: 0px;">
+                <a class="post-link" href="{{ post.url | relative_url }}">
+                    {{ post.title | escape }}
+                </a>
+            </h3>
+            {%- if site.show_excerpts -%}
+            <div style="color:gray;">{{ post.excerpt }}</div>
+            {%- endif -%}
+        </li>
+        {%- endfor -%}
     </ul>
-  {%- endif -%}
+    {%- endif -%}
 
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,30 +3,33 @@ layout: default
 ---
 <article class="post h-entry" itemscope itemtype="http://schema.org/BlogPosting">
 
-  <header class="post-header" style="margin-bottom: 0px;">
-    <h2 class="post-title p-name" itemprop="name headline" style="margin-bottom: 0px; font-size: 28px; line-height: 36px;">{{ page.title | escape }}</h2>
-    <p class="post-meta" style="margin-top: 5px; margin-bottom: 10px;">
-      Published on
-      <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
-        {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
-        {{ page.date | date: date_format }}
-      </time>
-      by&nbsp;
-      {%- if page.author -%}
-        <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span class="p-author h-card" itemprop="name">{{ page.author }}</span></span>
-      {%- else -%}
-        <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span class="p-author h-card" itemprop="name">Johnny Lin</span></span>
-      {%- endif -%}
-    </p>
-  </header>
+    <header class="post-header" style="margin-bottom: 0px;">
+        <h2 class="post-title p-name" itemprop="name headline"
+            style="margin-bottom: 0px; font-size: 28px; line-height: 36px;">{{ page.title | escape }}</h2>
+        <p class="post-meta" style="margin-top: 5px; margin-bottom: 10px;">
+            Published on
+            <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
+                {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+                {{ page.date | date: date_format }}
+            </time>
+            by&nbsp;
+            {%- if page.author -%}
+            <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span class="p-author h-card"
+                    itemprop="name">{{ page.author }}</span></span>
+            {%- else -%}
+            <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span class="p-author h-card"
+                    itemprop="name">Lockdown Privacy</span></span>
+            {%- endif -%}
+        </p>
+    </header>
 
-  <div class="post-content e-content" itemprop="articleBody">
-    {{ content }}
-  </div>
+    <div class="post-content e-content" itemprop="articleBody">
+        {{ content }}
+    </div>
 
-  {%- if site.disqus.shortname -%}
+    {%- if site.disqus.shortname -%}
     {%- include disqus_comments.html -%}
-  {%- endif -%}
+    {%- endif -%}
 
-  <a class="u-url" href="{{ page.url | relative_url }}" hidden></a>
+    <a class="u-url" href="{{ page.url | relative_url }}" hidden></a>
 </article>

--- a/_posts/2020-11-25-how-to-make-80000.markdown
+++ b/_posts/2020-11-25-how-to-make-80000.markdown
@@ -2,7 +2,7 @@
 title: How to Make $80,000 Per Month on the Apple App Store
 layout: post
 date: '2020-11-25 00:00:00 -0800'
-author: Johnny Lin
+author: Lockdown Privacy
 ---
 
 #### It’s far easier than you think. No luck or perseverance necessary.

--- a/_posts/2020-12-02-why-you-cant-trust.markdown
+++ b/_posts/2020-12-02-why-you-cant-trust.markdown
@@ -2,7 +2,7 @@
 title: Can You Trust the Apps and Sites You Use?
 layout: post
 date: '2020-12-02 00:00:00 -0800'
-author: Johnny Lin
+author: Lockdown Privacy
 ---
 
 #### Let's hope every tech company steals this idea.

--- a/_posts/2020-12-09-heres-what-the-do-not.markdown
+++ b/_posts/2020-12-09-heres-what-the-do-not.markdown
@@ -2,7 +2,7 @@
 title: The “Do Not Sell My Personal Data” Button Makes Absolutely No Sense
 layout: post
 date: '2020-12-09 00:00:00 -0800'
-author: Johnny Lin
+author: Lockdown Privacy
 ---
 
 #### Are there people who *want* their data to be sold?

--- a/_posts/2021-09-22-study-effectiveness-of-apples-app-tracking-transparency.md
+++ b/_posts/2021-09-22-study-effectiveness-of-apples-app-tracking-transparency.md
@@ -1,6 +1,6 @@
 ---
 title: 'Study: Effectiveness of Apple''s App Tracking Transparency'
-author: Johnny Lin and Sean Halloran
+author: Lockdown Privacy
 ---
 
 #### Does it stop third-party tracking? Or is it just an illusion of privacy?

--- a/_posts/2023-02-23-Lockdown-2-How-Were-Getting-There.md
+++ b/_posts/2023-02-23-Lockdown-2-How-Were-Getting-There.md
@@ -5,15 +5,13 @@ title: 'Lockdown 2.0: How We''re Getting There'
 #### Scaling Privacy to the Next 10 Million Users
 <!--more-->
 
-Hey— it’s Johnny and Rahul, co-founders of Lockdown Privacy.
-
 We’re pleased to announce that Lockdown Privacy has been acquired by Appex Group, a privacy-conscious mobile development group fully owned and operated by passionate technologists and engineers. Appex is headquartered in Boston, Massachusetts, and is led by open source veterans with extensive background in security. The Appex team was immediately attracted to Lockdown's industry-leading transparency, and saw that by prioritizing trust through transparency, Lockdown was able to grow organically to over a million users, instead of relying on invasive ads or marketing - a win for both user privacy and for Lockdown.
 
 Going forward, not only is the Appex team committed to operating Lockdown as open source, but they're also heavily investing in building out new privacy features and performance enhancements, such as a next-generation tracker-blocking engine that’s exponentially more efficient - updates that our two-person team didn't previously have the resources for.
 
 For us as founders, we're happy that Lockdown's new operators are folks who believe in the importance of privacy, and who arguably have much deeper experience with open source than us. Of course, actions speak louder than words, so this month, Appex is completing Lockdown's fifth audit by independent security and privacy experts - the update will be posted and announced in the next few weeks on OpenAudit.
 
-We look forward to continuing to work with Appex as strategic advisors - and if you have any questions, concerns, or feedback, you can reach Johnny at [johnny@lockdownprivacy.com](mailto:johnny@lockdownprivacy.com), and the Appex team at [team@lockdownprivacy.com](mailto:team@lockdownprivacy.com).
+We look forward to continuing to work with Appex as strategic advisors - and if you have any questions, concerns, or feedback, you can reach the Appex team at [team@lockdownprivacy.com](mailto:team@lockdownprivacy.com).
 
 Best,
 


### PR DESCRIPTION
## What?
Removed all mentions of personal names from all pages and posts.

## Examples
Old:
<img width="500" src="https://github.com/confirmedcode/Lockdown-Blog/assets/8799143/6aec6878-2428-4b04-a788-9b41472604b0" />
New:
<img width="500" src="https://github.com/confirmedcode/Lockdown-Blog/assets/8799143/f26cd201-d43b-46a0-b298-8b12a2ec2672" />

Old:
<img width="500" src="https://github.com/confirmedcode/Lockdown-Blog/assets/8799143/2e992736-57a1-4bac-a1c8-6489a4a100c7" />
New:
<img width="500" src="https://github.com/confirmedcode/Lockdown-Blog/assets/8799143/2e92bf35-aae3-4da8-aa6e-54322efdf455" />